### PR TITLE
Expose float80 only on macOS.

### DIFF
--- a/Gen.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
+++ b/Gen.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
@@ -5,4 +5,4 @@ Gen.bool.set(ofAtMost: .always(3)).run()
 Gen.float(in: 0...1)
 
 import CoreGraphics
-Gen.float80(in: 0...1)
+Gen.cgFloat(in: 0...1)

--- a/Sources/Gen/Gen.swift
+++ b/Sources/Gen/Gen.swift
@@ -275,6 +275,7 @@ extension Gen where Value == Float {
   }
 }
 
+#if os(macOS)
 extension Gen where Value == Float80 {
   /// Returns a generator of random values within the specified range.
   ///
@@ -285,6 +286,7 @@ extension Gen where Value == Float80 {
     return Gen { rng in .random(in: range, using: &rng) }
   }
 }
+#endif
 
 #if canImport(CoreGraphics)
 import CoreGraphics


### PR DESCRIPTION
Fixes #5 

I took the approach to simply omit `float80` from macOS since it's not supported on iOS. An alternative is to approximate `float80` using `NSDecimalNumber` (as seen [here](https://stackoverflow.com/questions/38276351/swift-float80-data-type-not-available-in-xcode-8-beta) and in this Stencil [PR](https://github.com/stencilproject/Stencil/commit/aa7c36296be051192956ba64fc18f6f4827895d1#diff-4725e5f88b796ab8d9cc184d8ef3c1adR4) where they had the same problem). However, `NSDecimalNumber` has much poorer performance than a natively supported `Float80`, so may be better for people to explicitly opt into a decimal number if that's what they want.

