### PR TITLE
Reproduce build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ install:
       eval "$(curl -sL https://swiftenv.fuller.li/install.sh)";
     fi
 script:
+  - swift build -c release
   - swift test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM finestructure/swift:swift-5.1-RELEASE
+FROM swift:5.1
 
 WORKDIR /package
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM norionomura/swift:swift-5.0-branch
+FROM finestructure/swift:swift-5.1-RELEASE
 
 WORKDIR /package
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ COPY . ./
 
 RUN swift package resolve
 RUN swift package clean
+RUN swift build -c release
 CMD swift test --parallel


### PR DESCRIPTION
I've stuck the release build command in the `Dockerfile` for sake of simplicity.

Note that the build crashes both the 5.0 and the 5.1 complier. I.e. it doesn't make a difference if it's

```
FROM finestructure/swift:swift-5.1-RELEASE
```

or

```
FROM norionomura/swift:swift-5.0-branch
```

The 5.1 image is created via this repo here: https://github.com/finestructure/docker-swift

There don't appear to be any official 5.1 images yet.