### PR TITLE
Restore Float80 support

### DIFF
--- a/Sources/Gen/Gen.swift
+++ b/Sources/Gen/Gen.swift
@@ -275,6 +275,19 @@ extension Gen where Value == Float {
   }
 }
 
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+  extension Gen where Value == Float80 {
+    /// Returns a generator of random values within the specified range.
+    ///
+    /// - Parameter range: The range in which to create a random value. `range` must be finite.
+    /// - Returns: A generator of random values within the bounds of range.
+    @inlinable
+    public static func float80(in range: ClosedRange<Value>) -> Gen {
+      return Gen { rng in .random(in: range, using: &rng) }
+    }
+  }
+#endif
+
 #if canImport(CoreGraphics)
   import CoreGraphics
 


### PR DESCRIPTION
Was drafting a release and thought that removing support was unfortunate, then I wondered if there was an arch check we could do, and a quick search in the Swift code bas showed that there is!

https://github.com/apple/swift/blob/113baa67ece33f130720e8b767b60f001e45acd5/stdlib/public/core/BuiltinMath.swift#L116