### PR TITLE
Add state initialization and visibility to Xoshiro

### DIFF
--- a/Sources/Gen/Xoshiro.swift
+++ b/Sources/Gen/Xoshiro.swift
@@ -35,3 +35,20 @@ public struct Xoshiro: RandomNumberGenerator {
     return result
   }
 }
+
+extension Xoshiro {
+  /// Initialize with a full state.
+  ///
+  /// Useful for getting an exact value from `next()` after multiple runs of the RNG.
+  @inlinable
+  public init(state: (UInt64, UInt64, UInt64, UInt64)) {
+    self.state = state
+  }
+
+  /// Get the latest internal state of the RNG.
+  ///
+  /// Can be used in combination with `init(state:)` to run the RNG from a specific state, e.g. in the context of a property-based test.
+  public var currentState: (UInt64, UInt64, UInt64, UInt64) {
+    state
+  }
+}


### PR DESCRIPTION
Hi people, in the last couple of years I've been using `swift-gen` to build a minimal property-based testing library (very minimal), by leveraging generators and the ability to explicitly pass a seed. This is required because, if a test fails, the "current" seed must be shown in assertion errors in order to rerun that specific iteration, with those specific inputs, for debugging purposes. With `LCRNG` it was easy: the seed was a simple number, stored in a public property. But I started working again on the project and noticed that you deprecated `LCRNG` and added `Xoshiro`: this is excellent, but I couldn't customize it the same way as `LCRNG`. In the case of `Xoshiro` I need to access the full state tuple, and call `init` with it.

So in this PR I thought about adding an extension to `Xoshiro` to do exactly that. I think this is required for a property-based testing library use case, and I doesn't seem to break invariants or the utility of `swift-gen` in general, so it seems pretty harmless. What do you think?