### PR TITLE
Make Gen<Int>.always expressible by integer literal

### DIFF
--- a/Sources/Gen/Gen.swift
+++ b/Sources/Gen/Gen.swift
@@ -557,3 +557,10 @@ extension Sequence {
     return self.traverse { $0 }
   }
 }
+
+extension Gen: ExpressibleByIntegerLiteral where Value == Int {
+  /// Instantiate `Gen<Int>.always(n)` from the integer literal `n`.
+  public init(integerLiteral value: Int) {
+    self = .always(value)
+  }
+}

--- a/Tests/GenTests/GenTests.swift
+++ b/Tests/GenTests/GenTests.swift
@@ -16,7 +16,7 @@ final class GenTests: XCTestCase {
   }
 
   func testFlatMap() {
-    let gen = Gen.bool.flatMap { bool in bool ? .always(1) : .always(2) }
+    let gen = Gen.bool.flatMap { bool in bool ? 1 : 2 }
     XCTAssertEqual(2, gen.run(using: &xoshiro))
   }
 
@@ -49,19 +49,19 @@ final class GenTests: XCTestCase {
     let gen = Gen.frequency((1, .always(1)), (4, .always(nil)))
     XCTAssertEqual(
       [1, 1, nil, nil, nil, nil, nil, nil, nil, nil],
-      gen.array(of: .always(10)).run(using: &xoshiro))
+      gen.array(of: 10).run(using: &xoshiro))
   }
 
   func testOptional() {
     let gen = Gen.bool.optional
     XCTAssertEqual(
       [nil, nil, true, false, false, false, false, false, false, nil],
-      gen.array(of: .always(10)).run(using: &xoshiro))
+      gen.array(of: 10).run(using: &xoshiro))
   }
 
   struct Failure: Error, Equatable {}
   func testResult() {
-    let gen = Gen.bool.asResult(withFailure: .always(Failure())).array(of: .always(10))
+    let gen = Gen.bool.asResult(withFailure: .always(Failure())).array(of: 10)
     XCTAssertEqual(
       [
         .failure(.init()),


### PR DESCRIPTION
There are a few built-in generators with a `Gen<Int>` argument in the library. By making `Gen<Int>.always` expressible by integer literal, one can drop `.always(n)` to conveniently write only `n` in constant setups.