### PR TITLE
Update readme with more clear name for package to help with installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you want to use Gen in a project that uses [SwiftPM](https://swift.org/packag
 
 ``` swift
 dependencies: [
-  .package(url: "https://github.com/pointfreeco/swift-gen.git", from: "0.3.0")
+  .package(name: "Gen", url: "https://github.com/pointfreeco/swift-gen.git", from: "0.3.0")
 ]
 ```
 


### PR DESCRIPTION
Motivation to update this was was due to confusion with package name.
Even though it's called "swift-gen" the actual package name is "Gen" so when trying to add this as dependancy to target it's not clear that "Gen" should be used instead of swift-gen".

Thank you for great work.